### PR TITLE
feat: add title and sr only text to links

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -59,6 +59,10 @@ main > .tagline {
 	padding: 10px;
 }
 
+.icons-social a {
+  text-decoration: none;
+}
+
 .devto {
 	margin-bottom: -0.20rem;
 }

--- a/index.html
+++ b/index.html
@@ -29,15 +29,42 @@
 		<div class="tagline">All-Star Dev | Code Fanatic | Linux Hacker | Bleh</div>
 		<!-- Find your icons from here - https://fontawesome.com/icons?d=gallery&s=brands -->
 		<div class="icons-social">
-			<a target="_blank" href="https://github.com/flexdinesh"><i class="fab fa-github"></i></a>
-			<a target="_blank" href="https://twitter.com/flexdinesh"><i class="fab fa-twitter"></i></a>
-			<a target="_blank" href="https://dev.to/flexdinesh"><i class="fab fa-dev"></i></a>
-			<a target="_blank" href="https://stackoverflow.com/story/flexdinesh"><i class="fab fa-stack-overflow"></i></a>
-			<a target="_blank" href="https://www.linkedin.com/in/dineshpandiyan"><i class="fab fa-linkedin"></i></a>
-			<a target="_blank" href="https://medium.com/@flexdinesh"><i class="fab fa-medium"></i></a>
-			<a target="_blank" href="https://www.freecodecamp.org"><i class="fab fa-free-code-camp"></i></a>
-			<a target="_blank" href="https://www.behance.net"><i class="fab fa-behance"></i></a>
-			<a target="_blank" href="https://codepen.io"><i class="fab fa-codepen"></i></a>
+			<a target="_blank" href="https://github.com/flexdinesh">
+        <i class="fab fa-github" aria-hidden="true" title="Github"></i>
+        <span class="sr-only">Github</span>
+      </a>
+      <a target="_blank" href="https://twitter.com/flexdinesh">
+        <i class="fab fa-twitter" aria-hidden="true" title="Twitter"></i>
+        <span class="sr-only">Twitter</span>
+      </a>
+      <a target="_blank" href="https://dev.to/flexdinesh">
+        <i class="fab fa-dev" aria-hidden="true" title="DEV Community"></i>
+        <span class="sr-only">DEV Community</span>
+      </a>
+      <a target="_blank" href="https://stackoverflow.com/story/flexdinesh">
+        <i class="fab fa-stack-overflow" aria-hidden="true" title="StackOverflow"></i>
+        <span class="sr-only">StackOverflow</span>
+      </a>
+      <a target="_blank" href="https://www.linkedin.com/in/dineshpandiyan">
+        <i class="fab fa-linkedin" aria-hidden="true" title="LinkedIn"></i>
+        <span class="sr-only">LinkedIn</span>
+      </a>
+      <a target="_blank" href="https://medium.com/@flexdinesh">
+        <i class="fab fa-medium" aria-hidden="true" title="Medium"></i>
+        <span class="sr-only">Medium</span>
+      </a>
+      <a target="_blank" href="https://www.freecodecamp.org">
+        <i class="fab fa-free-code-camp" aria-hidden="true" title="FreeCodeCamp"></i>
+        <span class="sr-only">FreeCodeCamp</span>
+      </a>
+      <a target="_blank" href="https://www.behance.net">
+        <i class="fab fa-behance" aria-hidden="true" title="Behance"></i>
+        <span class="sr-only">Behance</span>
+      </a>
+      <a target="_blank" href="https://codepen.io">
+        <i class="fab fa-codepen" aria-hidden="true" title="CodePen"></i>
+        <span class="sr-only">CodePen</span>
+      </a>
     </div>
 	</main>
 </body>


### PR DESCRIPTION
A few accessibility improvements [recommended by font-awesome](https://fontawesome.com/v5/docs/web/other-topics/accessibility#web-fonts-with-css-semantic-icons).

Adds to links:
- Title on hover
- Screen reader only text

![Screenshot from 2022-06-16 08-21-30](https://user-images.githubusercontent.com/7598058/173942142-9bff5819-78b2-4d03-b26d-617659fbb06e.png)

If you're happy to accept more PRs, I've got some other changes I'd like to suggest that I've made to [my dev landing page](https://benjamin.lol/).

Thanks for the great template! :) 